### PR TITLE
Load docker compose env vars and prepare template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to .env for server deployments
+
+# Docker Hub
+DOCKERHUB_USERNAME=
+
+# Django
+SECRET_KEY=
+# Prefer False in production; service-level override keeps container DEBUG off
+DEBUG=False
+
+# Database
+DB_NAME=mindjourney
+DB_USER=postgres
+DB_PASSWORD=postgres
+
+# External APIs
+GEMINI_API_KEY=

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -27,16 +27,13 @@ services:
 
   backend:
     image: ${DOCKERHUB_USERNAME}/mindjourney-backend:latest
+    env_file:
+      - .env
     environment:
       DEBUG: "False"
-      SECRET_KEY: ${SECRET_KEY}
-      DB_NAME: ${DB_NAME:-mindjourney}
-      DB_USER: ${DB_USER:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD:-postgres}
       DB_HOST: db
       DB_PORT: 5432
       REDIS_URL: redis://redis:6379/0
-      GEMINI_API_KEY: ${GEMINI_API_KEY}
     volumes:
       - static_volume:/app/staticfiles
       - media_volume:/app/media
@@ -53,16 +50,13 @@ services:
   celery:
     image: ${DOCKERHUB_USERNAME}/mindjourney-backend:latest
     command: celery -A mindjourney worker --loglevel=info
+    env_file:
+      - .env
     environment:
       DEBUG: "False"
-      SECRET_KEY: ${SECRET_KEY}
-      DB_NAME: ${DB_NAME:-mindjourney}
-      DB_USER: ${DB_USER:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD:-postgres}
       DB_HOST: db
       DB_PORT: 5432
       REDIS_URL: redis://redis:6379/0
-      GEMINI_API_KEY: ${GEMINI_API_KEY}
     volumes:
       - media_volume:/app/media
     depends_on:
@@ -76,16 +70,13 @@ services:
   celery-beat:
     image: ${DOCKERHUB_USERNAME}/mindjourney-backend:latest
     command: celery -A mindjourney beat --loglevel=info
+    env_file:
+      - .env
     environment:
       DEBUG: "False"
-      SECRET_KEY: ${SECRET_KEY}
-      DB_NAME: ${DB_NAME:-mindjourney}
-      DB_USER: ${DB_USER:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD:-postgres}
       DB_HOST: db
       DB_PORT: 5432
       REDIS_URL: redis://redis:6379/0
-      GEMINI_API_KEY: ${GEMINI_API_KEY}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Update `docker-compose.server.yml` to load environment variables from a `.env` file and provide a `.env.example` template for server deployments.

This centralizes environment variable configuration in a `.env` file, making it easier to manage sensitive information and deployment-specific settings for the server services.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7458d1c-118e-4941-baa8-dac5f7076e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7458d1c-118e-4941-baa8-dac5f7076e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

